### PR TITLE
Updated exit status to 0 when no strings found to prevent issues with…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 Cargo.lock
 .DS_Store
+.idea

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn print_remaining(count_remain: usize, quiet: bool) {
     if quiet.not() {
         if count_remain == 0 {
                 println!("No strings found.");
-                std::process::exit(1);
+                std::process::exit(0);
         }
         else {
             println!("Remaining strings: {}", count_remain);
@@ -287,7 +287,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>>  {
         if !quiet {
             println!("No strings found.");
         }
-        std::process::exit(1);
+        std::process::exit(0);
     }
 
     let pb_lang = ProgressBar::new(total_strings);


### PR DESCRIPTION
Refactor exit status. Other tools that take the exit status were flagging execution as failed when no strings were found, as the exit status was 1.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the exit status to 0 when no strings are found to ensure compatibility with other tools that interpret a non-zero exit status as a failure.

Bug Fixes:
- Change exit status to 0 when no strings are found to prevent other tools from flagging execution as failed.

<!-- Generated by sourcery-ai[bot]: end summary -->